### PR TITLE
Optimize CPU inference and add quantization

### DIFF
--- a/CPU_INFERENCE_OPTIMIZATION_PROBLEMS.md
+++ b/CPU_INFERENCE_OPTIMIZATION_PROBLEMS.md
@@ -1,0 +1,24 @@
+# CPU Inference Optimization Problems
+
+The following issues were identified when reviewing the CPU inference pipeline and have now been resolved:
+
+1. **Use of `torch.no_grad` instead of `torch.inference_mode`.**
+   - Several inference and scaling routines relied on `torch.no_grad`, which still incurs autograd setup costs. Replacing it with `torch.inference_mode` gives better performance on CPU.
+   - *Fix applied*: switched relevant contexts and decorators to `torch.inference_mode` in inference and scaler modules.
+
+2. **Repeated tensor concatenations in autoregressive loops.**
+   - Functions like `generate_mean` and `generate_samples` repeatedly called `torch.cat` inside loops, causing frequent memory reallocations.
+   - *Fix applied*: both routines now preallocate tensors to their final sizes and write predictions in place, eliminating repeated concatenations.
+
+3. **Inefficient timestamp and array construction.**
+   - `_generate` previously built timestamp arrays via Python loops and NumPy conversions, adding CPU overhead.
+   - *Fix applied*: timestamps are now constructed directly with vectorized PyTorch operations.
+
+4. **Potential gains from compilation and threading controls.**
+   - Compiling the model with `torch.compile`/`torch.jit` or tuning `torch.set_num_threads` can yield additional CPU speedups depending on the environment.
+   - *Fix applied*: `TotoForecaster` optionally compiles the model and allows setting the number of threads for CPU inference.
+
+5. **Missing post-training quantization.**
+   - Quantization can further accelerate CPU inference by using int8 weights.
+   - *Fix applied*: added utilities to apply dynamic post-training quantization and integrated optional quantization into the forecaster.
+

--- a/toto/inference/forecaster.py
+++ b/toto/inference/forecaster.py
@@ -20,6 +20,7 @@ from ..data.util.dataset import (
     replace_extreme_values,
 )
 from ..model.backbone import TotoBackbone
+from ..model.quantization import quantize_for_inference
 
 
 @dataclass(frozen=True)
@@ -82,9 +83,23 @@ class TotoForecaster:
 
     model: TotoBackbone
 
-    def __init__(self, model: TotoBackbone):
+    def __init__(
+        self,
+        model: TotoBackbone,
+        *,
+        compile: bool = False,
+        num_threads: int | None = None,
+        quantize: bool = False,
+    ):
+        if quantize:
+            model = quantize_for_inference(model)
+        if compile and hasattr(torch, "compile"):
+            model = torch.compile(model)  # type: ignore[attr-defined]
         self.model = model
-
+        if num_threads is not None:
+            torch.set_num_threads(num_threads)
+    
+    @torch.inference_mode()
     def forecast(
         self,
         inputs: MaskedTimeseries,
@@ -181,7 +196,7 @@ class TotoForecaster:
 
         return Forecast(mean=mean, samples=samples)
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def generate_mean(
         self,
         inputs: Float[torch.Tensor, "batch variate time_steps"],
@@ -202,60 +217,71 @@ class TotoForecaster:
         if id_mask is None:
             id_mask = torch.zeros_like(inputs, dtype=torch.int, device=inputs.device)
 
-        ## round up the prediction length to the nearest multiple of the patch size
         patch_size = self.model.patch_embed.stride
         rounded_steps = int(np.ceil(prediction_length / patch_size) * patch_size)
         start_index = inputs.shape[-1]
         end_index = start_index + prediction_length
+        final_len = start_index + rounded_steps
 
-        # TODO: maybe pass in future masks, rather than making assumptions here?
-        dummy_padding = torch.ones(
-            (input_padding_mask.shape[0], input_padding_mask.shape[1], patch_size),
+        # Preallocate buffers for future steps
+        input_buffer = torch.empty(
+            (inputs.shape[0], inputs.shape[1], final_len),
             device=inputs.device,
-            dtype=torch.bool,
+            dtype=inputs.dtype,
         )
-        dummy_id_mask = repeat(
+        input_buffer[:, :, :start_index] = inputs
+
+        id_buffer = torch.empty_like(input_buffer, dtype=id_mask.dtype)
+        id_buffer[:, :, :start_index] = id_mask
+        id_buffer[:, :, start_index:] = repeat(
             id_mask[:, :, -1:],
-            "batch variates 1 -> batch variates patch_size",
-            patch_size=patch_size,
+            "batch variates 1 -> batch variates time",
+            time=rounded_steps,
         )
+
+        padding_buffer = torch.ones(
+            (inputs.shape[0], inputs.shape[1], final_len),
+            dtype=torch.bool,
+            device=inputs.device,
+        )
+        padding_buffer[:, :, :start_index] = input_padding_mask
+
+        # Vectorized timestamp construction
+        timestamp_buffer = torch.empty_like(input_buffer, dtype=timestamp_seconds.dtype)
+        timestamp_buffer[:, :, :start_index] = timestamp_seconds
+        offsets = torch.arange(1, rounded_steps + 1, device=inputs.device, dtype=timestamp_seconds.dtype)
+        future_ts = timestamp_seconds[:, :, -1:] + time_interval_seconds.unsqueeze(-1) * offsets
+        timestamp_buffer[:, :, start_index:] = future_ts
+
         if use_kv_cache:
             kv_cache = self.model.allocate_kv_cache(
                 batch_size=inputs.shape[0],
                 num_variates=inputs.shape[1],
-                max_time_steps=inputs.shape[2] + rounded_steps,
+                max_time_steps=final_len,
                 device=inputs.device,
                 dtype=inputs.dtype,
             )
         else:
             kv_cache = None
 
-        scaling_prefix_length = inputs.shape[-1]
+        scaling_prefix_length = start_index
 
-        for _ in range(rounded_steps // patch_size):
+        for step in range(rounded_steps // patch_size):
+            cur_end = start_index + step * patch_size
             base_distr, loc, scale = self.model(
-                inputs=inputs,
-                input_padding_mask=input_padding_mask,
-                id_mask=id_mask,
+                inputs=input_buffer[:, :, :cur_end],
+                input_padding_mask=padding_buffer[:, :, :cur_end],
+                id_mask=id_buffer[:, :, :cur_end],
                 kv_cache=kv_cache,
                 scaling_prefix_length=scaling_prefix_length,
             )
             distr = self.create_affine_transformed(base_distr, loc, scale)
-
-            # We remove extreme values that can occur early in training
-            # and cause validation metrics to be NaN
             samples = replace_extreme_values(distr.mean[:, :, -patch_size:])
+            input_buffer[:, :, cur_end : cur_end + patch_size] = samples
 
-            inputs = torch.cat([inputs, samples], dim=-1)
-            id_mask = torch.cat([id_mask, dummy_id_mask], dim=-1)
-            input_padding_mask = torch.cat([input_padding_mask, dummy_padding], dim=-1)
-            for _ in range(patch_size):
-                next_timestamp: Int[torch.Tensor, "batch variate"] = timestamp_seconds[:, :, -1] + time_interval_seconds
-                timestamp_seconds = torch.cat([timestamp_seconds, next_timestamp.unsqueeze(-1)], dim=-1)
+        return input_buffer.detach()[:, :, start_index:end_index]
 
-        return inputs.detach()[:, :, start_index:end_index]
-
-    @torch.no_grad()
+    @torch.inference_mode()
     def generate_samples(
         self,
         inputs: Float[torch.Tensor, "batch variate time_steps"],
@@ -283,100 +309,103 @@ class TotoForecaster:
         assert num_samples % sampling_batch_size == 0, "num_samples must be divisible by sampling_batch_size"
         num_batches = num_samples // sampling_batch_size
 
-        # round up the prediction length to the nearest multiple of the patch size
         patch_size = self.model.patch_embed.patch_size
         rounded_steps = int(np.ceil(prediction_length / patch_size) * patch_size)
         start_index = inputs.shape[-1]
         end_index = start_index + prediction_length
+        final_len = start_index + rounded_steps
 
-        dummy_padding = torch.ones(
-            (
-                input_padding_mask.shape[0] * sampling_batch_size,
-                input_padding_mask.shape[1],
-                patch_size,
-            ),
-            dtype=torch.bool,
+        # Prepare templates for a sampling batch
+        template_inputs = torch.empty(
+            (inputs.shape[0] * sampling_batch_size, inputs.shape[1], final_len),
             device=inputs.device,
+            dtype=inputs.dtype,
         )
-        dummy_id_mask = repeat(
-            id_mask[:, :, -1:],
-            "batch variates 1 -> (sampling_batch_size batch) variates patch_size",
-            sampling_batch_size=sampling_batch_size,
-            patch_size=patch_size,
-        )
-        inputs = repeat(
+        template_inputs[:, :, :start_index] = repeat(
             inputs,
             "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
             sampling_batch_size=sampling_batch_size,
         )
-        input_padding_mask = repeat(
-            input_padding_mask,
-            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
-            sampling_batch_size=sampling_batch_size,
-        )
-        id_mask = repeat(
+
+        template_id_mask = torch.empty_like(template_inputs, dtype=id_mask.dtype)
+        template_id_mask[:, :, :start_index] = repeat(
             id_mask,
             "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
             sampling_batch_size=sampling_batch_size,
         )
-        timestamp_seconds = repeat(
+        template_id_mask[:, :, start_index:] = repeat(
+            id_mask[:, :, -1:],
+            "batch variates 1 -> (sampling_batch_size batch) variates time",
+            sampling_batch_size=sampling_batch_size,
+            time=rounded_steps,
+        )
+
+        template_padding = torch.ones_like(template_id_mask, dtype=torch.bool)
+        template_padding[:, :, :start_index] = repeat(
+            input_padding_mask,
+            "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
+            sampling_batch_size=sampling_batch_size,
+        )
+
+        ts_repeated = repeat(
             timestamp_seconds,
             "batch variates seq_len -> (sampling_batch_size batch) variates seq_len",
             sampling_batch_size=sampling_batch_size,
         )
-        time_interval_seconds = repeat(
+        intervals_repeated = repeat(
             time_interval_seconds,
             "batch variates -> (sampling_batch_size batch) variates",
             sampling_batch_size=sampling_batch_size,
         )
+        template_timestamps = torch.empty_like(template_inputs, dtype=timestamp_seconds.dtype)
+        template_timestamps[:, :, :start_index] = ts_repeated
+        offsets = torch.arange(1, rounded_steps + 1, device=inputs.device, dtype=timestamp_seconds.dtype)
+        future_ts = ts_repeated[:, :, -1:] + intervals_repeated.unsqueeze(-1) * offsets
+        template_timestamps[:, :, start_index:] = future_ts
 
-        all_samples = []
         if use_kv_cache:
             kv_cache = self.model.allocate_kv_cache(
-                batch_size=inputs.shape[0],
-                num_variates=inputs.shape[1],
-                max_time_steps=inputs.shape[2] + rounded_steps,
+                batch_size=template_inputs.shape[0],
+                num_variates=template_inputs.shape[1],
+                max_time_steps=final_len,
                 device=inputs.device,
                 dtype=inputs.dtype,
             )
         else:
             kv_cache = None
 
-        scaling_prefix_length = inputs.shape[-1]
+        scaling_prefix_length = start_index
 
-        for _ in range(num_batches):
-            batch_inputs = torch.clone(inputs)
-            batch_input_padding_mask = torch.clone(input_padding_mask)
-            batch_id_mask = torch.clone(id_mask)
-            batch_timestamp_seconds = torch.clone(timestamp_seconds)
+        outputs = torch.empty(
+            (inputs.shape[0] * num_samples, inputs.shape[1], final_len),
+            device=inputs.device,
+            dtype=inputs.dtype,
+        )
 
-            for _ in range(rounded_steps // patch_size):
+        for b in range(num_batches):
+            batch_start = b * template_inputs.shape[0]
+            batch_end = batch_start + template_inputs.shape[0]
+            batch_inputs = template_inputs.clone()
+
+            for step in range(rounded_steps // patch_size):
+                cur_end = start_index + step * patch_size
                 base_distr, loc, scale = self.model(
-                    inputs=batch_inputs,
-                    input_padding_mask=batch_input_padding_mask,
-                    id_mask=batch_id_mask,
+                    inputs=batch_inputs[:, :, :cur_end],
+                    input_padding_mask=template_padding[:, :, :cur_end],
+                    id_mask=template_id_mask[:, :, :cur_end],
                     kv_cache=kv_cache,
                     scaling_prefix_length=scaling_prefix_length,
                 )
                 distr = self.create_affine_transformed(base_distr, loc, scale)
-
                 sample = distr.sample()
                 assert sample is not None
-
-                # We remove extreme values that can occur early in training
-                # and cause validation metrics to be NaN
                 samples = replace_extreme_values(sample[:, :, -patch_size:])
-                batch_inputs = torch.cat([batch_inputs, samples], dim=-1)
-                batch_id_mask = torch.cat([batch_id_mask, dummy_id_mask], dim=-1)
-                batch_input_padding_mask = torch.cat([batch_input_padding_mask, dummy_padding], dim=-1)
-                for _ in range(patch_size):
-                    next_timestamp = batch_timestamp_seconds[:, :, -1] + time_interval_seconds
-                    batch_timestamp_seconds = torch.cat([batch_timestamp_seconds, next_timestamp.unsqueeze(-1)], dim=-1)
-            all_samples.append(batch_inputs)
+                batch_inputs[:, :, cur_end : cur_end + patch_size] = samples
+
+            outputs[batch_start:batch_end] = batch_inputs
             if kv_cache is not None:
                 kv_cache.reset()
 
-        outputs = torch.cat(all_samples, dim=0)
         unfolded_outputs = rearrange(
             outputs,
             "(samples batch) variates seq_len -> batch variates seq_len samples",

--- a/toto/inference/gluonts_predictor.py
+++ b/toto/inference/gluonts_predictor.py
@@ -72,6 +72,7 @@ class TotoSampleForecastGenerator(SampleForecastGenerator):
             else:
                 raise ValueError(f"Cannot handle frequency of type {type(freq)}: {freq}")
 
+    @torch.inference_mode()
     def _generate(
         self,
         inference_data_loader: DataLoader,
@@ -103,38 +104,29 @@ class TotoSampleForecastGenerator(SampleForecastGenerator):
                 num_variates=inputs.shape[1],
             )
 
-            # First, build a single NumPy array from your list comprehension
-            np_timestamps = np.array(
+            start_seconds = torch.tensor(
                 [
-                    (
-                        pd.period_range(
-                            start=forecast_start - forecast_start.freq,
-                            periods=inputs.shape[-1],
-                            freq=forecast_start.freq,
-                        )
-                        .to_timestamp(freq=forecast_start.freq)
-                        .view(np.int64)
-                        // int(1e9)  # Convert to Unix timestamp in seconds
-                    )
-                    .clip(INT_MIN, INT_MAX)
-                    .astype(int)  # Clamp to torch.int range
+                    int((forecast_start - forecast_start.freq).to_timestamp().value // 1_000_000_000)
                     for forecast_start in batch["forecast_start"]
-                ]
+                ],
+                dtype=torch.int,
+                device=inputs.device,
             )
-
-            # Then, create a tensor from the contiguous NumPy array
+            intervals = torch.tensor(
+                [self.freq_to_seconds(forecast_start.freq) for forecast_start in batch["forecast_start"]],
+                dtype=torch.int,
+                device=inputs.device,
+            )
+            offsets = torch.arange(inputs.shape[-1], device=inputs.device, dtype=torch.int)
+            ts = start_seconds.unsqueeze(-1) + intervals.unsqueeze(-1) * offsets
+            ts = ts.clamp(INT_MIN, INT_MAX)
             timestamps = repeat(
-                torch.tensor(np_timestamps, dtype=torch.int, device=inputs.device),
+                ts,
                 "batch time_steps -> batch num_variates time_steps",
                 num_variates=inputs.shape[1],
             )
-
             time_intervals = repeat(
-                torch.tensor(
-                    [self.freq_to_seconds(forecast_start.freq) for forecast_start in batch["forecast_start"]],
-                    dtype=torch.int,
-                    device=inputs.device,
-                ),
+                intervals,
                 "batch -> batch num_variates",
                 num_variates=inputs.shape[1],
             )
@@ -430,7 +422,7 @@ class TotoPredictor(PyTorchPredictor):
         if eval:
             self.prediction_net.eval()
 
-        with torch.no_grad():
+        with torch.inference_mode():
             yield from self.forecast_generator(
                 inference_data_loader=inference_data_loader,
                 prediction_net=self.prediction_net,

--- a/toto/model/quantization.py
+++ b/toto/model/quantization.py
@@ -1,0 +1,26 @@
+# Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+#
+# This product includes software developed at Datadog (https://www.datadoghq.com/)
+# Copyright 2025 Datadog, Inc.
+
+"""Utility functions for post-training quantization."""
+
+import torch
+from torch import nn
+
+
+def quantize_for_inference(model: nn.Module) -> nn.Module:
+    """Apply dynamic post-training quantization for inference.
+
+    This uses :func:`torch.quantization.quantize_dynamic` to convert supported
+    layers (currently ``nn.Linear``) to int8 representations which can speed up
+    CPU inference without requiring additional calibration data.
+
+    Args:
+        model: The trained model to quantize.
+
+    Returns:
+        A quantized copy of ``model`` suitable for CPU inference.
+    """
+
+    return torch.quantization.quantize_dynamic(model, {nn.Linear}, dtype=torch.qint8)

--- a/toto/model/scaler.py
+++ b/toto/model/scaler.py
@@ -47,7 +47,7 @@ class StdMeanScaler(Scaler):
         prefix_length: int | None = None,
     ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         assert data.shape == weights.shape, "data and weights must have same shape"
-        with torch.no_grad():
+        with torch.inference_mode():
             if prefix_length is not None:
                 # Create a prefix mask that is 1 for positions within prefix, 0 elsewhere
                 prefix_mask = torch.zeros_like(weights)
@@ -148,7 +148,7 @@ def compute_causal_statistics(
     # Assert that dim is -1 (last dimension)
     assert dim == -1, "compute_causal_statistics only supports dim=-1 (last dimension)"
 
-    with torch.no_grad():
+    with torch.inference_mode():
         # Apply padding mask to weights
         weights = weights * padding_mask
 
@@ -415,7 +415,7 @@ class CausalPatchStdMeanScaler(Scaler):
         assert data.shape == weights.shape, "data and weights must have same shape"
         assert len(data.shape) == 3, "Input data must have shape [batch, variates, time_steps]"
 
-        with torch.no_grad():
+        with torch.inference_mode():
             # Get the number of time steps (last dimension)
             time_steps = data.shape[-1]
 


### PR DESCRIPTION
## Summary
- preallocate tensors and vectorize timestamp generation for leaner CPU inference
- expose optional `torch.compile`, thread controls, and dynamic quantization in `TotoForecaster`
- document resolved CPU inference bottlenecks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e0b28c84c8333adfede8fe13a137d