### PR TITLE
Add Triton inference server wrapper

### DIFF
--- a/toto/inference/README.md
+++ b/toto/inference/README.md
@@ -1,0 +1,50 @@
+# Triton CPU Inference
+
+This directory contains a helper script to serve a Toto model using the
+[NVIDIA Triton Inference Server](https://github.com/triton-inference-server/server)
+with optimizations for CPU execution.
+
+## Preparing and launching the server
+
+1. **Install Triton** – ensure the `tritonserver` binary is available and the
+   Python backend is enabled.
+2. **Run the helper script** to create a Triton model repository and launch the
+   server:
+
+   ```bash
+   python toto/inference/run_triton_server.py \
+       --checkpoint /path/to/model.safetensors \
+       --repo model_repo \
+       --threads 8 \
+       --compile \
+       --quantize
+   ```
+
+   - `--threads` sets the number of CPU threads used by PyTorch.
+   - `--compile` compiles the model with `torch.compile`.
+   - `--quantize` applies dynamic post-training quantization.
+   - Use `--no-launch` to only create the repository without starting the
+     server.
+
+   The script copies the checkpoint and `triton_wrapper.py` into the model
+   repository and starts `tritonserver` with `OMP_NUM_THREADS` set for the
+   requested thread count.
+
+3. **Send requests** using one of the Triton clients. For example, using the
+   HTTP client:
+
+   ```python
+   import numpy as np
+   import tritonclient.http as httpclient
+
+   client = httpclient.InferenceServerClient("localhost:8000")
+   # Prepare numpy arrays for the required tensors...
+   result = client.infer("toto", inputs)
+   print(result.as_numpy("mean"))
+   ```
+
+## Customizing the repository
+
+`run_triton_server.py` writes a `config.pbtxt` that exposes parameters for
+`num_threads`, `compile` and `quantize`. These values can be manually edited in
+`model_repo/toto/config.pbtxt` for further tuning.

--- a/toto/inference/run_triton_server.py
+++ b/toto/inference/run_triton_server.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Launch Triton Inference Server for Toto with CPU optimizations."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+
+def prepare_repository(
+    checkpoint: str,
+    repo: Path,
+    *,
+    threads: int,
+    compile_model: bool,
+    quantize: bool,
+) -> None:
+    """Create a Triton model repository for Toto."""
+    model_dir = repo / "toto" / "1"
+    model_dir.mkdir(parents=True, exist_ok=True)
+
+    # Copy model checkpoint and wrapper.
+    shutil.copy(checkpoint, model_dir / "model.safetensors")
+    wrapper_src = Path(__file__).with_name("triton_wrapper.py")
+    shutil.copy(wrapper_src, model_dir / "model.py")
+
+    config = f"""
+    name: \"toto\"
+    backend: \"python\"
+    max_batch_size: 0
+    input [
+      {{ name: \"series\", data_type: TYPE_FP32, dims: [ -1, -1, -1 ] }},
+      {{ name: \"padding_mask\", data_type: TYPE_BOOL, dims: [ -1, -1, -1 ] }},
+      {{ name: \"id_mask\", data_type: TYPE_INT32, dims: [ -1, -1, -1 ] }},
+      {{ name: \"timestamp_seconds\", data_type: TYPE_INT32, dims: [ -1, -1, -1 ] }},
+      {{ name: \"time_interval_seconds\", data_type: TYPE_INT32, dims: [ -1, -1 ] }},
+      {{ name: \"prediction_length\", data_type: TYPE_INT32, dims: [1] }},
+      {{ name: \"num_samples\", data_type: TYPE_INT32, dims: [1], optional: true }}
+    ]
+    output [
+      {{ name: \"mean\", data_type: TYPE_FP32, dims: [ -1, -1, -1 ] }},
+      {{ name: \"samples\", data_type: TYPE_FP32, dims: [ -1, -1, -1, -1 ], optional: true }}
+    ]
+    parameters {{
+      key: \"num_threads\"
+      value {{ string_value: \"{threads}\" }}
+    }}
+    parameters {{
+      key: \"compile\"
+      value {{ string_value: \"{str(compile_model).lower()}\" }}
+    }}
+    parameters {{
+      key: \"quantize\"
+      value {{ string_value: \"{str(quantize).lower()}\" }}
+    }}
+    """
+    (repo / "toto" / "config.pbtxt").write_text(textwrap.dedent(config))
+
+
+def launch_server(repo: Path, *, threads: int) -> None:
+    """Start Triton Inference Server."""
+    env = os.environ.copy()
+    env.setdefault("OMP_NUM_THREADS", str(threads))
+    cmd = ["tritonserver", "--model-repository", str(repo)]
+    subprocess.run(cmd, env=env, check=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--checkpoint", required=True, help="Path to Toto checkpoint")
+    parser.add_argument("--repo", default="model_repo", help="Model repository directory")
+    parser.add_argument(
+        "--threads",
+        type=int,
+        default=os.cpu_count(),
+        help="Number of CPU threads for PyTorch",
+    )
+    parser.add_argument(
+        "--compile",
+        dest="compile_model",
+        action="store_true",
+        help="Compile model with torch.compile",
+    )
+    parser.add_argument(
+        "--quantize",
+        action="store_true",
+        help="Apply dynamic quantization",
+    )
+    parser.add_argument(
+        "--no-launch",
+        action="store_true",
+        help="Only create repository without starting server",
+    )
+    args = parser.parse_args()
+
+    repo = Path(args.repo)
+    prepare_repository(
+        args.checkpoint,
+        repo,
+        threads=args.threads,
+        compile_model=args.compile_model,
+        quantize=args.quantize,
+    )
+
+    if not args.no_launch:
+        launch_server(repo, threads=args.threads)
+
+
+if __name__ == "__main__":
+    main()

--- a/toto/inference/triton_wrapper.py
+++ b/toto/inference/triton_wrapper.py
@@ -1,0 +1,149 @@
+"""Triton Inference Server wrapper for Toto.
+
+This module provides a minimal integration layer between the Toto model and the
+NVIDIA Triton Inference Server using the Python backend.  The wrapper exposes a
+``TritonPythonModel`` class that can be dropped into a Triton model repository
+and used to serve Toto forecasts.  Only the pieces required for loading the
+model and producing forecasts are implemented; advanced features such as
+batching or dynamic batching can be added later if needed.
+
+Example Triton model repository structure::
+
+    models/
+      toto/
+        1/
+          model.safetensors
+          model.py  # <- this file
+        config.pbtxt
+
+The config should declare the inputs listed in ``execute`` below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+import torch
+
+# ``triton_python_backend_utils`` is only available inside the Triton Python
+# backend runtime.  Import lazily so that unit tests or other environments that
+# do not provide the module can still import this file without failing.
+try:  # pragma: no cover - small utility guard
+    import triton_python_backend_utils as pb_utils
+except Exception:  # pragma: no cover - the dependency is optional
+    pb_utils = None  # type: ignore
+
+from toto.data.util.dataset import MaskedTimeseries
+from toto.inference.forecaster import TotoForecaster
+from toto.model.toto import Toto
+
+
+class TritonPythonModel:  # pragma: no cover - exercised in Triton runtime
+    """Triton entry point for serving Toto forecasts.
+
+    The class follows the interface required by the Triton Python backend.  It
+    expects the model checkpoint (``model.safetensors`` by default) to live
+    under the version directory of the Triton model repository.  During
+    ``initialize`` the checkpoint is loaded and wrapped with :class:`TotoForecaster`.
+
+    Requests handled by ``execute`` must provide the following tensors:
+
+    - ``series``: ``float32``/``float64`` of shape ``(batch, variates, time)``.
+    - ``padding_mask``: ``bool`` mask of same shape as ``series`` indicating
+      valid values.
+    - ``id_mask``: ``int32``/``int64`` mask of same shape.
+    - ``timestamp_seconds``: ``int32``/``int64`` timestamp per element.
+    - ``time_interval_seconds``: ``int32``/``int64`` of shape ``(batch, variates)``.
+    - ``prediction_length``: scalar ``int32`` specifying the horizon.
+    - ``num_samples`` *(optional)*: scalar ``int32`` for stochastic sampling.
+
+    The response contains ``mean`` and, when sampling, ``samples`` tensors.
+    """
+
+    def initialize(self, args: Dict[str, Any]) -> None:
+        """Load the Toto checkpoint and create the forecaster."""
+
+        if pb_utils is None:  # pragma: no cover - safety for non-triton env
+            raise RuntimeError("triton_python_backend_utils is required inside Triton runtime")
+
+        model_config = json.loads(args["model_config"])
+        repo_path = args["model_repository"]
+        version = args["model_version"]
+
+        # Allow overriding checkpoint name via config parameters.
+        params = model_config.get("parameters", {})
+        checkpoint = params.get("checkpoint", {}).get("string_value", "model.safetensors")
+        compile_flag = params.get("compile", {}).get("string_value", "false").lower() in {"1", "true", "yes", "on"}
+        quantize_flag = params.get("quantize", {}).get("string_value", "false").lower() in {"1", "true", "yes", "on"}
+        num_threads_val = params.get("num_threads", {}).get("string_value")
+        num_threads = int(num_threads_val) if num_threads_val is not None else None
+
+        checkpoint_path = os.path.join(repo_path, version, checkpoint)
+
+        toto = Toto.load_from_checkpoint(checkpoint_path, map_location="cpu")
+        self.forecaster = TotoForecaster(
+            toto.model,
+            compile=compile_flag,
+            num_threads=num_threads,
+            quantize=quantize_flag,
+        )
+
+    def execute(self, requests: List[pb_utils.InferenceRequest]) -> List[pb_utils.InferenceResponse]:
+        """Run Toto forecasts for a list of Triton requests."""
+
+        responses: List[pb_utils.InferenceResponse] = []
+        for request in requests:
+            series = self._torch_tensor(request, "series")
+            padding_mask = self._torch_tensor(request, "padding_mask", dtype=torch.bool)
+            id_mask = self._torch_tensor(request, "id_mask", dtype=torch.int32)
+            timestamp_seconds = self._torch_tensor(request, "timestamp_seconds", dtype=torch.int32)
+            time_interval_seconds = self._torch_tensor(request, "time_interval_seconds", dtype=torch.int32)
+
+            prediction_length = int(pb_utils.get_input_tensor_by_name(request, "prediction_length").as_numpy().item())
+            num_samples_tensor = pb_utils.get_input_tensor_by_name(request, "num_samples")
+            num_samples: Optional[int] = None
+            if num_samples_tensor is not None:
+                num_samples = int(num_samples_tensor.as_numpy().item())
+
+            inputs = MaskedTimeseries(
+                series=series,
+                padding_mask=padding_mask,
+                id_mask=id_mask,
+                timestamp_seconds=timestamp_seconds,
+                time_interval_seconds=time_interval_seconds,
+            )
+
+            forecast = self.forecaster.forecast(
+                inputs,
+                prediction_length=prediction_length,
+                num_samples=num_samples,
+            )
+
+            output_tensors = [
+                pb_utils.Tensor("mean", forecast.mean.cpu().numpy()),
+            ]
+            if forecast.samples is not None:
+                output_tensors.append(pb_utils.Tensor("samples", forecast.samples.cpu().numpy()))
+
+            responses.append(pb_utils.InferenceResponse(output_tensors=output_tensors))
+
+        return responses
+
+    def _torch_tensor(
+        self,
+        request: pb_utils.InferenceRequest,
+        name: str,
+        *,
+        dtype: Optional[torch.dtype] = None,
+    ) -> torch.Tensor:
+        """Utility to fetch a tensor from the request as a Torch tensor."""
+
+        tensor = pb_utils.get_input_tensor_by_name(request, name)
+        array = tensor.as_numpy()
+        torch_tensor = torch.from_numpy(array)
+        if dtype is not None:
+            torch_tensor = torch_tensor.to(dtype)
+        return torch_tensor


### PR DESCRIPTION
## Summary
- add Triton Python backend wrapper to serve Toto forecasts
- load Toto checkpoint and produce mean and sample forecasts
- provide script and docs to launch a CPU-optimized Triton server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2f8ed52788333b3d480ee594acf7e